### PR TITLE
Fix missing MVC reference in Program

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using AccountingAPI.Data;
 using AccountingAPI.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- add `Microsoft.AspNetCore.Mvc` using so `[FromServices]` attribute resolves during build

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e07f399708330bd0c3a42cd449b52